### PR TITLE
Update 2023-06-13-lee23a.md

### DIFF
--- a/_posts/2023-06-13-lee23a.md
+++ b/_posts/2023-06-13-lee23a.md
@@ -21,7 +21,7 @@ layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR
 issn: 2640-3498
-id: cho23a
+id: lee23a
 month: 0
 tex_title: Rediscovery of CNN’s Versatility for Text-based Encoding of Raw Electronic
   Health Records

--- a/_posts/2023-06-13-lee23a.md
+++ b/_posts/2023-06-13-lee23a.md
@@ -21,7 +21,7 @@ layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR
 issn: 2640-3498
-id: lee23a
+id: cho23a
 month: 0
 tex_title: Rediscovery of CNN’s Versatility for Text-based Encoding of Raw Electronic
   Health Records
@@ -30,9 +30,11 @@ lastpage: 313
 page: 294-313
 order: 294
 cycles: false
-bibtex_author: Lee, Minjae and Hur, Kyunghoon and Kim, Jiyoun and Yoon, Jinsung and
+bibtex_author: Cho, Eunbyeol and Lee, Minjae and Hur, Kyunghoon and Kim, Jiyoun and Yoon, Jinsung and
   Choi, Edward
 author:
+- given: Eunbyeol
+  family: Cho
 - given: Minjae
   family: Lee
 - given: Kyunghoon


### PR DESCRIPTION
I've noticed that Eunbyeol Cho, the principal author of the paper titled "Rediscovery of CNN’s Versatility for Text-based Encoding of Raw Electronic Health Records", is missing from the author list on your GitHub repository but is included in the PDF version. Please update the GitHub author list to correctly reflect this.